### PR TITLE
Add blog detail page with reading progress and related posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@splinetool/runtime": "^1.12.73",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"embla-carousel-react": "^8.6.0",
 		"lenis": "^1.3.21",
 		"motion": "^12.38.0",
 		"next": "16.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      embla-carousel-react:
+        specifier: ^8.6.0
+        version: 8.6.0(react@19.2.4)
       lenis:
         specifier: ^1.3.21
         version: 1.3.21(react@19.2.4)
@@ -2821,6 +2824,19 @@ packages:
 
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
+
+  embla-carousel-react@8.6.0:
+    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  embla-carousel-reactive-utils@8.6.0:
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -8468,6 +8484,18 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  embla-carousel-react@8.6.0(react@19.2.4):
+    dependencies:
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
+      react: 19.2.4
+
+  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0: {}
 
   emoji-regex@10.6.0: {}
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,49 @@
+import { notFound } from "next/navigation"
+import type { Metadata } from "next"
+import { blogPosts } from "@/data/blog-posts"
+import { BlogDetail } from "@/components/blog/blog-detail"
+import { RelatedPosts } from "@/components/blog/related-posts"
+
+interface BlogPostPageProps {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateStaticParams() {
+  return blogPosts.map((post) => ({
+    slug: post.slug,
+  }))
+}
+
+export async function generateMetadata({
+  params,
+}: BlogPostPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const post = blogPosts.find((p) => p.slug === slug)
+
+  if (!post) {
+    return {
+      title: "Post Not Found | Modern Scholar",
+    }
+  }
+
+  return {
+    title: `${post.title} | Modern Scholar`,
+    description: post.excerpt,
+  }
+}
+
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+  const { slug } = await params
+  const post = blogPosts.find((p) => p.slug === slug)
+
+  if (!post) {
+    notFound()
+  }
+
+  return (
+    <div className="page-padding-y flex gap-20 flex-col">
+      <BlogDetail post={post} />
+      <RelatedPosts post={post} />
+    </div>
+  )
+}

--- a/src/components/blog/blog-card-related.tsx
+++ b/src/components/blog/blog-card-related.tsx
@@ -1,26 +1,26 @@
-"use client"
+"use client";
 
-import Image from "next/image"
+import Image from "next/image";
 import Link from "next/link";
-import { motion } from "motion/react"
-import { Icon } from "@iconify/react"
-import type { BlogPost } from "@/data/blog-posts"
-import { glassPill } from "@/components/ui/styles"
-import { cn } from "@/lib/utils"
+import { motion } from "motion/react";
+import { Icon } from "@iconify/react";
+import type { BlogPost } from "@/data/blog-posts";
+import { glassPill } from "@/components/ui/styles";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button/button";
 
 interface BlogCardProps {
-  post: BlogPost
+  post: BlogPost;
 }
 
-export function BlogCard({ post }: BlogCardProps) {
+export function BlogCardRelated({ post }: BlogCardProps) {
   return (
     <Link href={`/blog/${post.slug}`} className="block h-full">
       <motion.div
         whileHover={{ scale: 1.009 }}
         transition={{ type: "spring", stiffness: 300, damping: 20 }}
         className={cn(
-          "group relative flex h-full flex-col overflow-hidden cursor-pointer rounded-2xl border border-white/40 bg-white/25 p-8 shadow-md hover:shadow-xl transition-shadow duration-300",
+          "group relative flex h-full flex-col overflow-hidden cursor-pointer rounded-2xl border border-white/40 bg-white/25 p-8 shadow-sm hover:shadow-lg transition-shadow duration-300",
           "dark:border-white/10 dark:bg-white/10",
         )}
       >
@@ -57,20 +57,20 @@ export function BlogCard({ post }: BlogCardProps) {
         </p>
 
         {/* Metadata row */}
-        <div className="mt-auto flex items-center justify-between pt-4">
+        {/* <div className="mt-auto flex items-center justify-between pt-4">
           <div className="flex items-center gap-2 text-xs">
             <span className="text-on-surface-variant">Published</span>
             <span className="font-medium text-on-surface">
               {post.publishDate}
             </span>
           </div>
-        </div>
+        </div> */}
 
         {/* Footer: read time + arrow */}
         <div className="flex items-center justify-between">
-          <span className="text-xs font-medium text-on-surface">
+          {/* <span className="text-xs font-medium text-on-surface">
             {post.readTime}
-          </span>
+          </span> */}
           <Button
             onClick={(e) => {
               e.stopPropagation();

--- a/src/components/blog/blog-detail.tsx
+++ b/src/components/blog/blog-detail.tsx
@@ -1,0 +1,278 @@
+"use client"
+
+import { useRef } from "react"
+import Image from "next/image"
+import Link from "next/link"
+import { Icon } from "@iconify/react"
+import type { BlogPost } from "@/data/blog-posts"
+import { glassPill } from "@/components/ui/styles"
+import { cn } from "@/lib/utils"
+import { AnimatedSection } from "@/components/ui/animatedSection/animated-section"
+import { Button } from "@/components/ui/button/button"
+import { ReadingProgress } from "@/components/blog/reading-progress"
+
+const ARTICLE_SECTIONS = [
+  { id: "section-landscape", title: "Understanding the Scholarship Landscape" },
+  { id: "section-application", title: "Building a Strong Application" },
+  { id: "section-applicationn", title: "Building a Strong Applicationn" },
+]
+
+interface BlogDetailProps {
+  post: BlogPost
+}
+
+export function BlogDetail({ post }: BlogDetailProps) {
+  const articleRef = useRef<HTMLElement>(null)
+
+  return (
+    <div>
+      <AnimatedSection variant="fadeUp">
+        <Link href="/blog">
+          <Button variant="ghost" size="sm" data-icon="inline-start">
+            <Icon icon="solar:arrow-left-linear" data-icon="inline-start" />
+            Back to Blog
+          </Button>
+        </Link>
+      </AnimatedSection>
+
+      <article
+        ref={articleRef}
+        className="mt-8 grid grid-cols-1 gap-10 md:grid-cols-[300px_1fr]"
+      >
+        {/* Article Content */}
+        <div className="relative order-first md:order-last">
+          {/* Title */}
+          <AnimatedSection variant="fadeUp">
+            <h1 className="font-heading text-3xl font-bold leading-tight text-on-surface md:text-4xl lg:text-5xl">
+              {post.title}
+            </h1>
+          </AnimatedSection>
+
+          {/* Excerpt */}
+          <AnimatedSection variant="fadeUp" delay={0.1}>
+            <p className="mt-4 text-lg leading-relaxed text-on-surface-variant md:text-xl">
+              {post.excerpt}
+            </p>
+          </AnimatedSection>
+
+          {/* Hero Image */}
+          <AnimatedSection variant="fadeUp" delay={0.2}>
+            <div className="relative mt-8 aspect-video w-full overflow-hidden rounded-2xl">
+              <Image
+                src="/mountain.png"
+                alt={post.title}
+                fill
+                className="object-cover"
+                sizes="(max-width: 768px) 100vw, 66vw"
+                priority
+              />
+            </div>
+          </AnimatedSection>
+
+          {/* Placeholder Prose Content */}
+          <div className="mt-10 space-y-8">
+            <AnimatedSection variant="fadeUp" delay={0.3}>
+              <h2
+                id="section-landscape"
+                className="font-heading text-2xl font-medium text-on-surface md:text-3xl"
+              >
+                Understanding the Scholarship Landscape
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-on-surface-variant">
+                The journey to securing a scholarship begins long before you
+                fill out your first application. It starts with understanding
+                the landscape — knowing what types of scholarships exist, who
+                offers them, and what they&apos;re really looking for in
+                candidates. Most students only scratch the surface, focusing on
+                the most well-known opportunities while missing thousands of
+                niche scholarships that could be a perfect fit.
+              </p>
+              <p className="mt-4 text-base leading-relaxed text-on-surface-variant">
+                Research is your most powerful tool. Spend time exploring
+                databases, talking to your school&apos;s financial aid office,
+                and connecting with organizations in your field of study. The
+                more targeted your search, the better your chances of finding
+                opportunities where you&apos;re not competing against tens of
+                thousands of applicants.
+              </p>
+            </AnimatedSection>
+
+            <AnimatedSection variant="fadeUp" delay={0.1}>
+              <blockquote className="border-l-4 border-primary/40 pl-6 italic text-on-surface-variant">
+                &ldquo;The students who succeed aren&apos;t necessarily the ones
+                with the highest grades — they&apos;re the ones who tell the
+                most compelling stories about who they are and where
+                they&apos;re going.&rdquo;
+              </blockquote>
+            </AnimatedSection>
+
+            <AnimatedSection variant="fadeUp" delay={0.1}>
+              <h2
+                id="section-application"
+                className="font-heading text-2xl font-medium text-on-surface md:text-3xl"
+              >
+                Building a Strong Application
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-on-surface-variant">
+                A strong scholarship application is more than a list of
+                achievements. It&apos;s a narrative that connects your
+                experiences, your goals, and the specific opportunity
+                you&apos;re applying for. Reviewers read hundreds of
+                applications — yours needs to stand out by being authentic,
+                specific, and memorable.
+              </p>
+
+              <ul className="mt-4 list-disc space-y-2 pl-6 text-base leading-relaxed text-on-surface-variant">
+                <li>
+                  Start your essay with a specific moment or experience, not a
+                  generic statement about your passion for learning.
+                </li>
+                <li>
+                  Tailor every application to the specific scholarship&apos;s
+                  mission and values — avoid generic, one-size-fits-all
+                  responses.
+                </li>
+                <li>
+                  Quantify your impact wherever possible: &ldquo;organized a
+                  tutoring program that served 50 students&rdquo; is stronger
+                  than &ldquo;helped other students.&rdquo;
+                </li>
+                <li>
+                  Ask for recommendation letters at least three weeks in
+                  advance, and provide your recommenders with context about the
+                  scholarship.
+                </li>
+                <li>
+                  Proofread ruthlessly — spelling and grammar errors signal a
+                  lack of care and attention to detail.
+                </li>
+              </ul>
+            </AnimatedSection>
+
+            <AnimatedSection variant="fadeUp" delay={0.1}>
+              <h2
+                id="section-application"
+                className="font-heading text-2xl font-medium text-on-surface md:text-3xl"
+              >
+                Building a Strong Applicationn
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-on-surface-variant">
+                A strong scholarship application is more than a list of
+                achievements. It&apos;s a narrative that connects your
+                experiences, your goals, and the specific opportunity
+                you&apos;re applying for. Reviewers read hundreds of
+                applications — yours needs to stand out by being authentic,
+                specific, and memorable.
+              </p>
+
+              <ul className="mt-4 list-disc space-y-2 pl-6 text-base leading-relaxed text-on-surface-variant">
+                <li>
+                  Start your essay with a specific moment or experience, not a
+                  generic statement about your passion for learning.
+                </li>
+                <li>
+                  Tailor every application to the specific scholarship&apos;s
+                  mission and values — avoid generic, one-size-fits-all
+                  responses.
+                </li>
+                <li>
+                  Quantify your impact wherever possible: &ldquo;organized a
+                  tutoring program that served 50 students&rdquo; is stronger
+                  than &ldquo;helped other students.&rdquo;
+                </li>
+                <li>
+                  Ask for recommendation letters at least three weeks in
+                  advance, and provide your recommenders with context about the
+                  scholarship.
+                </li>
+                <li>
+                  Proofread ruthlessly — spelling and grammar errors signal a
+                  lack of care and attention to detail.
+                </li>
+              </ul>
+            </AnimatedSection>
+
+            <AnimatedSection variant="fadeUp" delay={0.1}>
+              <p className="text-base leading-relaxed text-on-surface-variant">
+                Remember that{" "}
+                <a
+                  href="#"
+                  className="font-medium text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  financial aid offices
+                </a>{" "}
+                are valuable resources that many students overlook. They can
+                help you identify opportunities, review your applications, and
+                connect you with alumni who have successfully navigated the
+                scholarship process. Don&apos;t hesitate to{" "}
+                <a
+                  href="#"
+                  className="font-medium text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  reach out for guidance
+                </a>{" "}
+                — it could make the difference between a good application and a
+                winning one.
+              </p>
+            </AnimatedSection>
+          </div>
+        </div>
+
+        {/* Sidebar — renders above content on mobile via order */}
+        <aside className="order-last md:order-first">
+          <div className="sticky top-32 flex flex-col gap-6">
+            <AnimatedSection variant="fadeUp" delay={0.2}>
+              <div className="flex flex-col gap-4 rounded-2xl border border-white/40 bg-white/25 p-6 shadow-md backdrop-blur-2xl dark:border-white/10 dark:bg-white/10">
+                {/* Category */}
+                <div>
+                  <span className="text-xs font-medium uppercase tracking-wider text-on-surface-variant">
+                    Category
+                  </span>
+                  <div className="mt-2">
+                    <span
+                      className={cn(
+                        glassPill,
+                        "inline-flex items-center gap-2 px-3.5 py-1 text-xs tracking-wider",
+                      )}
+                    >
+                      <span className="size-1.5 rounded-full bg-on-surface" />
+                      <span className="text-on-surface">{post.category}</span>
+                    </span>
+                  </div>
+                </div>
+
+                {/* Publish Date */}
+                <div>
+                  <span className="text-xs font-medium uppercase tracking-wider text-on-surface-variant">
+                    Published
+                  </span>
+                  <p className="mt-1 text-sm font-medium text-on-surface">
+                    {post.publishDate}
+                  </p>
+                </div>
+
+                {/* Read Time */}
+                <div>
+                  <span className="text-xs font-medium uppercase tracking-wider text-on-surface-variant">
+                    Read Time
+                  </span>
+                  <p className="mt-1 text-sm font-medium text-on-surface">
+                    {post.readTime}
+                  </p>
+                </div>
+              </div>
+            </AnimatedSection>
+
+            {/* Reading progress: section dots + parallax waves + percentage */}
+            <AnimatedSection variant="fadeUp" delay={0.3}>
+            <ReadingProgress
+              articleRef={articleRef}
+              sections={ARTICLE_SECTIONS}
+            />
+            </AnimatedSection>
+          </div>
+        </aside>
+      </article>
+    </div>
+  );
+}

--- a/src/components/blog/reading-progress.tsx
+++ b/src/components/blog/reading-progress.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { useState, type RefObject } from "react"
+import {
+  motion,
+  useScroll,
+  useMotionValueEvent,
+} from "motion/react"
+
+interface Section {
+  id: string
+  title: string
+}
+
+interface ReadingProgressProps {
+  articleRef: RefObject<HTMLElement | null>
+  sections: Section[]
+}
+
+export function ReadingProgress({
+  articleRef,
+  sections,
+}: ReadingProgressProps) {
+  const [percentage, setPercentage] = useState(0)
+  const [activeIndex, setActiveIndex] = useState(-1)
+
+  const { scrollYProgress } = useScroll({
+    target: articleRef,
+    offset: ["start start", "end end"],
+  })
+
+  useMotionValueEvent(scrollYProgress, "change", (latest) => {
+    setPercentage(Math.round(latest * 100))
+
+    // Determine active section based on element positions
+    const viewportCenter = window.innerHeight / 2
+    let currentIndex = -1
+    for (let i = sections.length - 1; i >= 0; i--) {
+      const el = document.getElementById(sections[i].id)
+      if (el) {
+        const rect = el.getBoundingClientRect()
+        if (rect.top <= viewportCenter) {
+          currentIndex = i
+          break
+        }
+      }
+    }
+    setActiveIndex(currentIndex)
+  })
+
+  return (
+    <div className="overflow-hidden rounded-2xl flex flex-col gap-4 border border-white/40 bg-white/25 p-4 shadow-md backdrop-blur-2xl dark:border-white/10 dark:bg-white/10">
+      {/* Section breadcrumb dots */}
+      <div className="flex flex-col gap-2.5">
+        {sections.map((section, i) => {
+          const isActive = i === activeIndex
+          return (
+            <button
+              key={section.id}
+              className="flex items-center gap-2.5 text-left"
+            >
+              <motion.div
+                className="shrink-0 rounded-full bg-primary"
+                animate={{
+                  width: isActive ? 10 : 6,
+                  height: isActive ? 10 : 6,
+                  opacity: isActive ? 1 : 0.3,
+                }}
+                transition={{ type: "spring", stiffness: 300, damping: 25 }}
+              />
+              <span
+                className={`truncate text-xs transition-colors duration-200 ${
+                  isActive
+                    ? "font-medium text-on-surface"
+                    : "text-on-surface-variant"
+                }`}
+              >
+                {section.title}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Percentage */}
+      <div className="mt-4 flex items-center justify-between">
+        <span className="font-heading text-xs tracking-wider text-on-surface-variant">
+          Reading Progress
+        </span>
+        <motion.span
+          key={Math.floor(percentage / 10)}
+          initial={{ scale: 1.3 }}
+          animate={{ scale: 1 }}
+          transition={{ type: "spring", stiffness: 300, damping: 15 }}
+          className="font-heading text-sm font-medium text-on-surface"
+        >
+          {percentage}%
+        </motion.span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/blog/related-posts.tsx
+++ b/src/components/blog/related-posts.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import type { BlogPost } from "@/data/blog-posts"
+import { blogPosts } from "@/data/blog-posts"
+import { BlogCardRelated } from "@/components/blog/blog-card-related"
+import { AnimatedSection } from "@/components/ui/animatedSection/animated-section"
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from "@/components/ui/carousel"
+
+interface RelatedPostsProps {
+  post: BlogPost
+}
+
+export function RelatedPosts({ post }: RelatedPostsProps) {
+  const relatedPosts = blogPosts
+    .filter((p) => p.category === post.category && p.id !== post.id)
+    .slice(0, 6)
+
+  if (relatedPosts.length === 0) return null
+
+  return (
+    <AnimatedSection variant="fadeUp">
+      <section className="mt-16">
+        <div className="mb-8 flex items-center justify-between">
+          <h2 className="font-heading text-2xl font-medium text-on-surface md:text-3xl">
+            Related Articles
+          </h2>
+        </div>
+
+        <Carousel
+          opts={{
+            align: "start",
+            loop: false,
+          }}
+          className="w-full"
+        >
+          {/* Navigation arrows above carousel on the right */}
+          <div className="-mt-14 mb-4 flex items-center justify-end gap-2">
+            <CarouselPrevious
+              className="static translate-y-0"
+              variant="outline"
+              size="icon-sm"
+            />
+            <CarouselNext
+              className="static translate-y-0"
+              variant="outline"
+              size="icon-sm"
+            />
+          </div>
+
+          <CarouselContent className="-ml-4">
+            {relatedPosts.map((relatedPost) => (
+              <CarouselItem
+                key={relatedPost.id}
+                className="basis-full pl-4 md:basis-1/2 lg:basis-1/3"
+              >
+                <BlogCardRelated post={relatedPost} />
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+        </Carousel>
+      </section>
+    </AnimatedSection>
+  );
+}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,242 @@
+"use client"
+
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button/button"
+import { Icon } from "@iconify/react"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+function Carousel({
+  orientation = "horizontal",
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & CarouselProps) {
+  const [carouselRef, api] = useEmblaCarousel(
+    {
+      ...opts,
+      axis: orientation === "horizontal" ? "x" : "y",
+    },
+    plugins
+  )
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+  const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+  const onSelect = React.useCallback((api: CarouselApi) => {
+    if (!api) return
+    setCanScrollPrev(api.canScrollPrev())
+    setCanScrollNext(api.canScrollNext())
+  }, [])
+
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev()
+  }, [api])
+
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext()
+  }, [api])
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault()
+        scrollPrev()
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault()
+        scrollNext()
+      }
+    },
+    [scrollPrev, scrollNext]
+  )
+
+  React.useEffect(() => {
+    if (!api || !setApi) return
+    setApi(api)
+  }, [api, setApi])
+
+  React.useEffect(() => {
+    if (!api) return
+    onSelect(api)
+    api.on("reInit", onSelect)
+    api.on("select", onSelect)
+
+    return () => {
+      api?.off("select", onSelect)
+    }
+  }, [api, onSelect])
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api: api,
+        opts,
+        orientation:
+          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }}
+    >
+      <div
+        onKeyDownCapture={handleKeyDown}
+        className={cn("relative", className)}
+        role="region"
+        aria-roledescription="carousel"
+        data-slot="carousel"
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  )
+}
+
+function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div
+      ref={carouselRef}
+      className="overflow-hidden"
+      data-slot="carousel-content"
+    >
+      <div
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      role="group"
+      aria-roledescription="slide"
+      data-slot="carousel-item"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CarouselPrevious({
+  className,
+  variant = "outline",
+  size = "icon-sm",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      data-slot="carousel-previous"
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute touch-manipulation rounded-full",
+        orientation === "horizontal"
+          ? "top-1/2 -left-12 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <Icon icon="solar:alt-arrow-left-linear" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+}
+
+function CarouselNext({
+  className,
+  variant = "outline",
+  size = "icon-sm",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      data-slot="carousel-next"
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute touch-manipulation rounded-full",
+        orientation === "horizontal"
+          ? "top-1/2 -right-12 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <Icon icon="solar:alt-arrow-right-linear" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+}
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+  useCarousel,
+}


### PR DESCRIPTION
Introduces the blog detail page at /blog/[slug] with a reading progress bar, full post content layout, and related posts carousel. Updates blog cards to link to individual post pages.