### PR TITLE
💄 Polish blog imagery + fix expanding search wrapper

### DIFF
--- a/content/blog/how-to-write-a-winning-scholarship-essay.mdx
+++ b/content/blog/how-to-write-a-winning-scholarship-essay.mdx
@@ -5,6 +5,7 @@ category: "Tips & Guides"
 publishDate: "2026-03-08"
 author: Catherine Dumenu
 coverImage: /blog/bookShelf.png
+featured: true
 ---
 Master the art of scholarship essay writing with these proven strategies that have helped thousands of students secure funding.
 

--- a/src/components/blog/blog-card-featured.tsx
+++ b/src/components/blog/blog-card-featured.tsx
@@ -50,8 +50,21 @@ export function BlogCardFeatured({ post }: BlogCardFeaturedProps) {
             onError={() => setImgError(true)}
           />
 
-          {/* Gradient overlay — vertical from transparent to dark */}
-          <div className="absolute inset-0 bg-linear-to-b from-black/10 via-black/30 to-black/80" />
+          {/* Overlay #3 — editorial bottom fade in brand color */}
+          {/* Top: fixed warm-cream lift (theme-stable) so the photo dissolves into the page */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 h-1/3"
+            style={{
+              background:
+                "linear-gradient(to bottom, oklch(0.95 0.012 55 / 0.45), transparent)",
+            }}
+          />
+          {/* Bottom: primary-900 scrim for type legibility */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-3/4 bg-linear-to-t from-primary-900/95 via-primary-900/55 to-transparent"
+          />
 
           {/* Content overlaid on image */}
           <div className="absolute inset-0 flex flex-col justify-end p-6 sm:p-8 md:p-12">

--- a/src/components/blog/blog-card.tsx
+++ b/src/components/blog/blog-card.tsx
@@ -70,6 +70,16 @@ export function BlogCard({ post, variant = "default" }: BlogCardProps) {
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
             onError={() => setImgError(true)}
           />
+          {/* Soft primary tint — single light multiply pass */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 mix-blend-multiply bg-primary/20"
+          />
+          {/* Subtle bottom anchor */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 bg-linear-to-b from-transparent to-primary-900/65"
+          />
         </div>
 
         <div className="flex flex-1 flex-col p-6">

--- a/src/components/blog/blog-detail-hero-image.tsx
+++ b/src/components/blog/blog-detail-hero-image.tsx
@@ -12,14 +12,26 @@ export function BlogDetailHeroImage({ src, alt }: BlogDetailHeroImageProps) {
   const [imgError, setImgError] = useState(false)
 
   return (
-    <Image
-      src={imgError ? "/mountain.png" : src}
-      alt={alt}
-      fill
-      className="object-cover"
-      sizes="(max-width: 768px) 100vw, 66vw"
-      priority
-      onError={() => setImgError(true)}
-    />
-  )
+    <>
+      <Image
+        src={imgError ? "/mountain.png" : src}
+        alt={alt}
+        fill
+        className="object-cover"
+        sizes="(max-width: 768px) 100vw, 66vw"
+        priority
+        onError={() => setImgError(true)}
+      />
+      {/* Soft primary tint — single light multiply pass */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 mix-blend-multiply bg-primary/30"
+      />
+      {/* Subtle bottom anchor */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-linear-to-b from-transparent to-primary-900/35"
+      />
+    </>
+  );
 }

--- a/src/components/blog/blog-filters.tsx
+++ b/src/components/blog/blog-filters.tsx
@@ -234,28 +234,32 @@ export function BlogFilters({
               : "text-on-surface/60 dark:text-white/50",
           )}
         />
-        <Input
-          ref={inputRef}
-          type="search"
-          value={searchQuery}
-          onChange={(e) => onSearchChange(e.target.value)}
-          onFocus={() => setSearchOpen(true)}
-          onBlur={() => {
-            if (!searchQuery) setSearchOpen(false);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") {
-              onSearchChange("");
-              inputRef.current?.blur();
-            }
-          }}
-          placeholder="Search blogs"
-          aria-label="Search blogs"
+        <div
           className={cn(
-            "h-auto border-0 bg-transparent px-0 py-0 ring-0 focus-visible:border-0 focus-visible:ring-0",
-            !searchOpen && "w-0",
+            "flex min-w-0 items-center overflow-hidden",
+            searchOpen ? "flex-1" : "w-0",
           )}
-        />
+        >
+          <Input
+            ref={inputRef}
+            type="search"
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            onFocus={() => setSearchOpen(true)}
+            onBlur={() => {
+              if (!searchQuery) setSearchOpen(false);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                onSearchChange("");
+                inputRef.current?.blur();
+              }
+            }}
+            placeholder="Search blogs"
+            aria-label="Search blogs"
+            className="h-auto border-0 bg-transparent px-0 py-0 ring-0 focus-visible:border-0 focus-visible:ring-0"
+          />
+        </div>
       </motion.div>
     </div>
   );

--- a/src/components/scholarships/scholarship-filters.tsx
+++ b/src/components/scholarships/scholarship-filters.tsx
@@ -158,31 +158,35 @@ export function ScholarshipFilters({
                 )}
               />
             </button>
-            <Input
-              ref={inputRef}
-              id="scholarship-search-input"
-              type="search"
-              value={filters.searchQuery}
-              onChange={(e) => filters.setSearchQuery(e.target.value)}
-              onFocus={() => setSearchOpen(true)}
-              onBlur={() => {
-                if (!filters.searchQuery) setSearchOpen(false);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") {
-                  filters.setSearchQuery("");
-                  inputRef.current?.blur();
-                }
-              }}
-              placeholder="Search..."
-              aria-label="Search scholarships"
-              aria-hidden={!searchOpen}
-              tabIndex={searchOpen ? 0 : -1}
+            <div
               className={cn(
-                "h-auto border-0 bg-transparent px-0 py-0 ring-0 focus-visible:border-0 focus-visible:ring-0",
-                !searchOpen && "invisible w-0",
+                "flex min-w-0 items-center overflow-hidden",
+                searchOpen ? "flex-1" : "invisible w-0",
               )}
-            />
+            >
+              <Input
+                ref={inputRef}
+                id="scholarship-search-input"
+                type="search"
+                value={filters.searchQuery}
+                onChange={(e) => filters.setSearchQuery(e.target.value)}
+                onFocus={() => setSearchOpen(true)}
+                onBlur={() => {
+                  if (!filters.searchQuery) setSearchOpen(false);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    filters.setSearchQuery("");
+                    inputRef.current?.blur();
+                  }
+                }}
+                placeholder="Search..."
+                aria-label="Search scholarships"
+                aria-hidden={!searchOpen}
+                tabIndex={searchOpen ? 0 : -1}
+                className="h-auto border-0 bg-transparent px-0 py-0 ring-0 focus-visible:border-0 focus-visible:ring-0"
+              />
+            </div>
           </motion.div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Visual polish on the blog cards/hero plus a small layout fix for the expanding search input.

- **Card overlays** — featured card gets a warm-cream top fade and a primary-900 bottom scrim for type legibility; default card and detail hero get a soft primary multiply tint plus a subtle bottom anchor.
- **Expanding search wrapper** — wrap the toggleable search input (blog + scholarship filters) in a flex container so the clear button (added in #33) renders correctly when expanded.
- **Featured flag** — mark "How to Write a Winning Scholarship Essay" as featured.

## Test plan

- [ ] `/blog` listing — featured card scrim reads cleanly in light + dark
- [ ] `/blog/<slug>` — hero image overlay does not crush text contrast
- [ ] Click the search icon on `/blog` and `/scholarships` — input expands smoothly, clear (×) button appears and fully clears the value

🤖 Generated with [Claude Code](https://claude.com/claude-code)